### PR TITLE
Use supertest to test api

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "babel-eslint": "^4.1.3",
     "chai": "^3.3.0",
     "mocha": "^2.3.3",
-    "request": "^2.65.0",
     "semistandard": "^7.0.2",
     "supertest": "^1.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "bin/server.js",
   "scripts": {
     "start": "node index.js",
-    "test": "semistandard && scripts/test",
+    "test": "bash scripts/test",
     "check-style": "semistandard || true"
   },
   "repository": {

--- a/test/apis/user.js
+++ b/test/apis/user.js
@@ -1,14 +1,12 @@
-/*global describe it before beforeEach after afterEach */
+/*global describe it before after */
 'use strict';
 
 let expect = require('chai').expect;
-let request = require('request');
+let request = require('supertest');
 let fixture = require('../fixtures/users.json');
 
 module.exports = (app, db) => {
   describe('User API', () => {
-    // launching app via 'http' to expose server.close()
-    let Server = require('http').createServer(app);
     // setup the model
     let Model = db.User;
     let user1 = new Model(fixture[0]);
@@ -23,39 +21,31 @@ module.exports = (app, db) => {
 
     after((done) => done());
 
-    beforeEach((done) => {
-      Server.listen(4000, () => done());
-    });
-
-    afterEach((done) => {
-      Server.close(() => done());
-    });
-
     it('should list all users', (done) => {
-      let options = {
-        url: 'http://localhost:4000/api/users/',
-        headers: [ 'content-type: application/json' ]
-      };
-      request(options, (err, res, body) => {
-        body = JSON.parse(body);
-        expect(err).to.be.null;
-        expect(user1.username).to.equal(body[0].username);
-        expect(user2.username).to.equal(body[1].username);
-        done();
-      });
+      request(app)
+        .get('/api/users')
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .end((err, res) => {
+          expect(err).to.be.null;
+          expect(res.body[0].username).to.equal(user1.username);
+          expect(res.body[1].username).to.equal(user2.username);
+          done();
+        });
     });
 
     it('should get a user by id', (done) => {
-      let options = {
-        url: 'http://localhost:4000/api/users/' + user1._id,
-        headers: [ 'content-type: application/json' ]
-      };
-      request(options, (err, res, body) => {
-        body = JSON.parse(body);
-        expect(err).to.be.null;
-        expect(user1.username).to.equal(body.username);
-        done();
-      });
+      request(app)
+        .get('/api/users/' + user1._id)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .end((err, res) => {
+          expect(err).to.be.null;
+          expect(res.body.username).to.equal(user1.username);
+          done();
+        });
     });
   });
 };


### PR DESCRIPTION
- Saves a few lines, runs tests slightly faster, and tests are more readable.
- Fixes npm test script
